### PR TITLE
Document GraphQL subscriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -615,7 +615,7 @@ The Sorare API provides different GraphQL events to subscribe to:
 
 - `aCardWasUpdated`: triggers every time a card is updated
 - `bundledAuctionWasUpdated`: triggers every time a (bundled) english auction is updated
-- `currentUserWasUpdated`: triggers every time the current-user is updated (onyl works if authenticated)
+- `currentUserWasUpdated`: triggers every time the current-user is updated (only works if authenticated)
 - `gameWasUpdated`: triggers every time a game is updated
 - `offerWasUpdated`: triggers every time an offer is updated
 - `packWasSold`: triggers every time a pack is sold

--- a/README.md
+++ b/README.md
@@ -615,9 +615,9 @@ The Sorare API provides different GraphQL events to subscribe to:
 
 - `aCardWasUpdated`: triggers every time a card is updated
 - `bundledAuctionWasUpdated`: triggers every time a (bundled) english auction is updated
-- `currentUserWasUpdated`: triggers every time the current-user is updated (only works if authenticated)
+- `currentUserWasUpdated`: scoped to the current user, triggers every time the current user is updated (only works when authenticated)
 - `gameWasUpdated`: triggers every time a game is updated
-- `offerWasUpdated`: triggers every time an offer is updated
+- `offerWasUpdated`: scoped to received and sender of the offer, triggers every time an offer is updated (only works when authenticated with the sender or the receiver)
 
 The websocket URL to use is `wss://ws.sorare.com/cable`.
 

--- a/README.md
+++ b/README.md
@@ -608,3 +608,60 @@ Here are the few steps required to create an offer:
    ```
 
 A working JavaScript code sample is available in [examples/acceptSingleSaleOffer.js](./examples/acceptSingleSaleOffer.js).
+
+## Subscribing to GraphQL events
+
+The Sorare API provides different GraphQL events to subscribe to:
+
+- `aCardWasUpdated`: triggers every time a card is updated
+- `bundledAuctionWasUpdated`: triggers every time a (bundled) english auction is updated
+- `currentUserWasUpdated`: triggers every time the current-user is updated (onyl works if authenticated)
+- `gameWasUpdated`: triggers every time a game is updated
+- `offerWasUpdated`: triggers every time an offer is updated
+- `packWasSold`: triggers every time a pack is sold
+
+The websocket URL to use is `wss://ws.sorare.com/cable`.
+
+Sorare's GraphQL subscriptions are implemented through websockets with the `actioncable-v1-json` sub-protocol. Sorare relies on [ActionCable](https://guides.rubyonrails.org/action_cable_overview.html) because the [sorare.com](https://sorare.com) website has been scaled on a Ruby on Rails stack.
+
+In order to ease the websocket + `actioncable-v1-json` sub-protocoal usage outside of a Ruby on Rails environment, you can use the TypeScript/JavaScript package `@sorare/actioncable`:
+
+```bash
+$ yarn add @sorare/actioncable
+```
+
+```js
+const { ActionCable } = require("@sorare/actioncable");
+
+const cable = new ActionCable({
+  headers: {
+    // 'Authorization': `Bearer <YourJWTorOAuthToken>`,
+    // 'APIKEY': '<YourOptionalAPIKey>'
+  },
+});
+
+cable.subscribe("aCardWasUpdated { id }", {
+  connected() {
+    console.log("connected");
+  },
+
+  disconnected(error) {
+    console.log("disconnected", error);
+  },
+
+  rejected(error) {
+    console.log("rejected", error);
+  },
+
+  received(data) {
+    const aCardWasUpdated = data?.result?.data?.aCardWasUpdated;
+    if (!aCardWasUpdated) {
+      return;
+    }
+    const { id } = aCardWasUpdated;
+    console.log("a card was updated", id);
+  },
+});
+```
+
+A working JavaScript code sample is available in [examples/subscribeAllCardUpdates.js](./examples/subscribeAllCardUpdates.js).

--- a/README.md
+++ b/README.md
@@ -618,7 +618,6 @@ The Sorare API provides different GraphQL events to subscribe to:
 - `currentUserWasUpdated`: triggers every time the current-user is updated (only works if authenticated)
 - `gameWasUpdated`: triggers every time a game is updated
 - `offerWasUpdated`: triggers every time an offer is updated
-- `packWasSold`: triggers every time a pack is sold
 
 The websocket URL to use is `wss://ws.sorare.com/cable`.
 

--- a/README.md
+++ b/README.md
@@ -624,7 +624,7 @@ The websocket URL to use is `wss://ws.sorare.com/cable`.
 
 Sorare's GraphQL subscriptions are implemented through websockets with the `actioncable-v1-json` sub-protocol. Sorare relies on [ActionCable](https://guides.rubyonrails.org/action_cable_overview.html) because the [sorare.com](https://sorare.com) website has been scaled on a Ruby on Rails stack.
 
-In order to ease the websocket + `actioncable-v1-json` sub-protocoal usage outside of a Ruby on Rails environment, you can use the TypeScript/JavaScript package `@sorare/actioncable`:
+In order to ease the websocket + `actioncable-v1-json` sub-protocoal usage outside of a Ruby on Rails environment, you can use the TypeScript/JavaScript package [`@sorare/actioncable`](https://github.com/sorare/actioncable):
 
 ```bash
 $ yarn add @sorare/actioncable

--- a/examples/package.json
+++ b/examples/package.json
@@ -1,6 +1,7 @@
 {
   "license": "MIT",
   "dependencies": {
+    "@sorare/actioncable": "^1.0.3",
     "@sorare/crypto": "^1.0.0",
     "crypto": "^1.0.1",
     "graphql": "^16.2.0",

--- a/examples/requirements.txt
+++ b/examples/requirements.txt
@@ -1,0 +1,1 @@
+websocket-client

--- a/examples/subscribeAllCardUpdates.js
+++ b/examples/subscribeAllCardUpdates.js
@@ -1,0 +1,42 @@
+const { ActionCable } = require('@sorare/actioncable');
+
+const cable = new ActionCable({
+  headers: {
+    // 'Authorization': `Bearer <YourJWTorOAuthToken>`,
+    // 'APIKEY': '<YourOptionalAPIKey>'
+  }
+});
+
+cable.subscribe('aCardWasUpdated { id }', {
+  connected() {
+    console.log("connected");
+  },
+
+  disconnected(error) {
+    console.log("disconnected", error);
+  },
+
+  rejected(error) {
+    console.log("rejected", error);
+  },
+
+  received(data) {
+    const aCardWasUpdated = data?.result?.data?.aCardWasUpdated;
+    if (!aCardWasUpdated) {
+      return;
+    }
+    const { id } = aCardWasUpdated;
+    console.log('a card was updated', id);
+  }
+});
+
+cable.subscribe('bundledAuctionWasUpdated { id }', {
+  received(data) {
+    const bundledAuctionWasUpdated = data?.result?.data?.bundledAuctionWasUpdated;
+    if (!bundledAuctionWasUpdated) {
+      return;
+    }
+    const { id } = bundledAuctionWasUpdated;
+    console.log('a bundled auction was updated', id);
+  }
+});

--- a/examples/subscribeAllCardUpdates.js
+++ b/examples/subscribeAllCardUpdates.js
@@ -7,7 +7,7 @@ const cable = new ActionCable({
   }
 });
 
-cable.subscribe('aCardWasUpdated { id }', {
+cable.subscribe('aCardWasUpdated { slug }', {
   connected() {
     console.log("connected");
   },
@@ -25,8 +25,8 @@ cable.subscribe('aCardWasUpdated { id }', {
     if (!aCardWasUpdated) {
       return;
     }
-    const { id } = aCardWasUpdated;
-    console.log('a card was updated', id);
+    const { slug } = aCardWasUpdated;
+    console.log('a card was updated', slug);
   }
 });
 

--- a/examples/subscribe_all_card_updates.py
+++ b/examples/subscribe_all_card_updates.py
@@ -1,0 +1,54 @@
+import websocket
+import json
+import time
+
+w_socket = 'wss://ws.sorare.com/cable'
+identifier = json.dumps({"channel": "GraphqlChannel"})
+
+subscription_query = {
+  "query": "subscription { aCardWasUpdated { slug } }",
+  "variables": {},
+  "action": "execute"
+}
+
+def on_open(ws):
+  subscribe_command = {"command": "subscribe", "identifier": identifier}
+  ws.send(json.dumps(subscribe_command).encode())
+
+  time.sleep(1)
+
+  message_command = {
+    "command": "message",
+    "identifier": identifier,
+    "data": json.dumps(subscription_query)
+  }
+  ws.send(json.dumps(message_command).encode())
+
+def on_message(ws, data):
+  message = json.loads(data)
+  type = message.get('type')
+  if type == 'welcome':
+    pass
+  elif type == 'ping':
+    pass
+  elif message.get('message') is not None:
+    print(message['message'])
+
+def on_error(ws, error):
+  print('Error:', error)
+
+def on_close(ws, close_status_code, close_message):
+  print('WebSocket Closed:', close_message, close_status_code)
+
+def long_connection():
+  ws = websocket.WebSocketApp(
+    w_socket,
+    on_message=on_message,
+    on_close=on_close,
+    on_error=on_error,
+    on_open=on_open
+  )
+  ws.run_forever()
+
+if __name__ == '__main__':
+  long_connection()

--- a/examples/yarn.lock
+++ b/examples/yarn.lock
@@ -2,6 +2,13 @@
 # yarn lockfile v1
 
 
+"@sorare/actioncable@^1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@sorare/actioncable/-/actioncable-1.0.3.tgz#262910d3ed226d30fbd0a67c5535f13581a5722c"
+  integrity sha512-2c8tDIS975Uc9RsddBsCjM9U1Mgc/h+nC7f9gXRc/+tvsQr5plfKik0vDDa9ddyuRWLIeBwIFz36W5wp7RLaCA==
+  dependencies:
+    ws "^8.4.0"
+
 "@sorare/crypto@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@sorare/crypto/-/crypto-1.0.0.tgz#31e193c14ca43e14b6e146b1a9cd09277b453d02"
@@ -886,6 +893,11 @@ wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
+
+ws@^8.4.0:
+  version "8.4.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.4.0.tgz#f05e982a0a88c604080e8581576e2a063802bed6"
+  integrity sha512-IHVsKe2pjajSUIl4KYMQOdlyliovpEPquKkqbwswulszzI7r0SfQrxnXdWAEqOlDCLrVSJzo+O1hAwdog2sKSQ==
 
 y18n@^5.0.5:
   version "5.0.8"


### PR DESCRIPTION
The underlying `actioncable-v1-json` sub-protocol used by sorare.com's websockets makes it fairly complex to implement GraphQL subscriptions.

This officializes the `@sorare/actioncable` package and describe how to use it.

Fix#23