### PR TITLE
Documentation using graphql python gql

### DIFF
--- a/README.md
+++ b/README.md
@@ -941,7 +941,7 @@ subscription {
 
 A working JavaScript code sample is available in [examples/subscribeTokenWasUpdated.js](./examples/subscribeTokenWasUpdated.js).
 
-### Python
+### Python with websocket-client
 
 ```bash
 $ pip3 install websocket-client
@@ -1006,3 +1006,49 @@ if __name__ == '__main__':
 ```
 
 A working Python3 code sample is available in [examples/subscribe_all_card_updates.py](./examples/subscribe_all_card_updates.py).
+
+### Python with graphql-python/gql
+
+Using the [gqlactioncable](https://github.com/leszekhanusz/gql-actioncable) package, it is now possible
+to make subscriptions using [graphql-python/gql](https://github.com/graphql-python/gql).
+
+```bash
+$ pip install gqlactioncable
+```
+
+```python
+import asyncio
+
+from gql import Client, gql
+
+from gqlactioncable import ActionCableWebsocketsTransport
+
+
+async def main():
+
+    transport = ActionCableWebsocketsTransport(
+        url="wss://ws.sorare.com/cable",
+    )
+
+    async with Client(transport=transport) as session:
+
+        subscription = gql(
+            """
+            subscription onAnyCardUpdated {
+              aCardWasUpdated {
+                slug
+              }
+            }
+        """
+        )
+
+        async for result in session.subscribe(subscription):
+            print(result)
+
+
+asyncio.run(main())
+```
+
+This example is available in [examples/gql_subscription_all_cards.py](./examples/gql_subscription_all_cards.py).
+
+See also an example for http queries with gql: [examples/gql_query_all_cards.py](./examples/gql_query_all_cards.py)

--- a/README.md
+++ b/README.md
@@ -1051,4 +1051,4 @@ asyncio.run(main())
 
 This example is available in [examples/gql_subscription_all_cards.py](./examples/gql_subscription_all_cards.py).
 
-See also an example for http queries with gql: [examples/gql_query_all_cards.py](./examples/gql_query_all_cards.py)
+See also an example for http queries with gql: [examples/gql_query_all_cards.py](./examples/gql_query_all_cards.py).

--- a/examples/gql_query_all_cards.py
+++ b/examples/gql_query_all_cards.py
@@ -1,0 +1,38 @@
+# First install:
+# pip install gql[aiohttp]
+
+import asyncio
+
+from gql import Client, gql
+from gql.transport.aiohttp import AIOHTTPTransport
+
+
+async def main():
+
+    transport = AIOHTTPTransport(
+        url="https://api.sorare.com/graphql",
+        # headers = {"Authorization": "Bearer <TheUserAccessToken>"}
+    )
+
+    async with Client(transport=transport) as session:
+
+        query = gql(
+            """
+            query getAllCards {
+                allCards {
+                    nodes {
+                        name
+                        age
+                    }
+                }
+            }
+        """
+        )
+
+        result = await session.execute(query)
+
+        for card in result["allCards"]["nodes"]:
+            print(f"  Age: {card['age']}, Name: {card['name']}")
+
+
+asyncio.run(main())

--- a/examples/gql_subscription_all_cards.py
+++ b/examples/gql_subscription_all_cards.py
@@ -1,0 +1,34 @@
+# First install:
+# pip install gqlactioncable
+
+import asyncio
+
+from gql import Client, gql
+
+from gqlactioncable import ActionCableWebsocketsTransport
+
+
+async def main():
+
+    transport = ActionCableWebsocketsTransport(
+        url="wss://ws.sorare.com/cable",
+        keep_alive_timeout=60,
+    )
+
+    async with Client(transport=transport) as session:
+
+        subscription = gql(
+            """
+            subscription onAnyCardUpdated {
+              aCardWasUpdated {
+                slug
+              }
+            }
+        """
+        )
+
+        async for result in session.subscribe(subscription):
+            print(result)
+
+
+asyncio.run(main())


### PR DESCRIPTION
Hi,

I'm the maintainer of [graphql-python/gql](https://github.com/graphql-python/gql) :wave: and to solve issue [graphql-python/gql#254](https://github.com/graphql-python/gql/issues/254) I created the new package [gqlactioncable](https://github.com/leszekhanusz/gql-actioncable).

It allows to use gql to make subscriptions on the ActionCable transport used here.

In this PR, I added two executable python examples (for a query and for subscriptions) and modified the README.md to show how to use it.

This would allow users to use the full power of gql including:
- [easy subscriptions](https://gql.readthedocs.io/en/latest/usage/subscriptions.html)
- [async usage](https://gql.readthedocs.io/en/latest/async/async_usage.html#async-usage)
- [multiple subscriptions on the same websockets connection](https://gql.readthedocs.io/en/latest/advanced/async_advanced_usage.html#async-advanced-usage)
- [converting scalars and enums to Python types](https://gql.readthedocs.io/en/latest/usage/custom_scalars_and_enums.html)
- [having a permanent reconnecting session with exponential backoff and jitter](https://gql.readthedocs.io/en/latest/advanced/async_permanent_session.html)