### PR TITLE
Fixes sorare/api#276

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,7 +388,7 @@ Anonymous calls have the following limits:
 - depth: 2
 - complexity: 500
 
-Authenticated calls with a OAuth Token have the following limits:
+Authenticated calls with an OAuth Token have the following limits:
 
 - depth 5
 - complexity: 500

--- a/README.md
+++ b/README.md
@@ -388,6 +388,11 @@ Anonymous calls have the following limits:
 - depth: 2
 - complexity: 500
 
+Authenticated calls with a OAuth Token have the following limits:
+
+- depth 5
+- complexity: 500
+
 Authenticated calls (with a JWT Token or an API key) have the following limits:
 
 - depth 10


### PR DESCRIPTION
Added documentation of complexity and depth limit for OAuth authenticated requests to README.md of sorare api. 5 and 500 are the limits I found by several tests with OAuth auth.