### PR TITLE
Add ownedSinceAfter argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to the Sorare GraphQL API will be documented in this file. W
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2022-10-13
+
+### Added
+
+Added the following argument on `PublicUserInfoInterface.paginatedCards` and `WithPublicCardsInterface.cards`:
+
+- `ownedSinceAfter`
+
 ## 2022-10-05
 
 ### Added


### PR DESCRIPTION
Add ownedSinceAfter argument to PublicUserInfoInterface.paginatedCards and WithPublicCardsInterface.cards

Fix #240 