### PR TITLE
Deprecate currentUser's directOffer fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to the Sorare GraphQL API will be documented in this file. W
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2023-02-13
+
+### Deprecated
+
+Deprecated the following `currentUser` fields:
+
+- `directOffers`: use `tokenOffers`
+- `pendingDirectOffersSent`: use `pendingTokenOffersSent`
+- `endedDirectOffersSent`: use `endedTokenOffersSent`
+- `pendingDirectOffersReceived`: use `pendingTokenOffersReceived`
+- `endedDirectOffersReceived`: use `endedTokenOffersReceived`
+
 ## 2023-02-10
 
 ### Removed


### PR DESCRIPTION
Should use sport-agnostic `tokenOffer` fields instead.