### PR TITLE
Documenting fields dropped (deprecated on 2023-09-28)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to the Sorare GraphQL API will be documented in this file. W
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2023-11-06
+
+Dropped the following deprecated fields:
+
+- `user.highlightedDeck`: Use `userSportProfile.highlightedDeck`
+- `deckInFormation`: no longer maintained
+- `football.deckInFormation`: no longer maintained
+
 ## 2023-10-27
 
 Starting from 10/30/2023, the `id` field of the `User` and `CurrentUser` types will always be returned with the following format: `User:<id>`. Before this date, the format was inconsistent between `<id>` and `User:<id>` depending on the query.


### PR DESCRIPTION
Fields have been deprecated for over a month and have just been removed from the GraphQL schema.