### PR TITLE
Fix API URL in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,7 +374,7 @@ $ curl -X POST "https://api.sorare.com/oauth/token" \
 You can revoke the token
 
 ```bash
-$ curl -X POST "https//api.sorare.com/oauth/revoke" \
+$ curl -X POST "https://api.sorare.com/oauth/revoke" \
  -H 'content-type: application/x-www-form-urlencoded' \
  -d "client_id=<YourOAuthUID>&client_secret=<YourOAuthSecret>&token=<TheUserAccessToken>"
 ```

--- a/README.md
+++ b/README.md
@@ -374,7 +374,7 @@ $ curl -X POST "https://api.sorare.com/oauth/token" \
 You can revoke the token
 
 ```bash
-$ curl -X POST "https///api.sorare.com/oauth/revoke" \
+$ curl -X POST "https//api.sorare.com/oauth/revoke" \
  -H 'content-type: application/x-www-form-urlencoded' \
  -d "client_id=<YourOAuthUID>&client_secret=<YourOAuthSecret>&token=<TheUserAccessToken>"
 ```


### PR DESCRIPTION
In the "You can revoke the token" section, there seems to be a typo in the URL. It should be "https://api.sorare.com/oauth/revoke" instead of "https///api.sorare.com/oauth/revoke."