### PR TITLE
Fix refresh_token redundancy in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,7 +344,7 @@ $ curl -X POST "https://api.sorare.com/oauth/token" \
 -H 'content-type: application/x-www-form-urlencoded' \
 -d 'client_id=<YourOAuthUID>&client_secret=<YourOAuthSecret>&code=<TheRetrievedCode>&grant_type=authorization_code&redirect_uri=<TheSameCallbackURIAsBefore>'
 
-{"access_token":"....", "refresh_token": "....", "token_type":"Bearer","expires_in":7200,"refresh_token":"...","scope":"public","created_at":1639608238}
+{"access_token":"....", "refresh_token": "....", "token_type":"Bearer","expires_in":7200,"scope":"public","created_at":1639608238}
 ```
 
 You can then use the `access_token` the same way you would use a JWT token:


### PR DESCRIPTION
In the example under the "Refresh an OAuth token" section, there's a repetition of the "refresh_token" field in the response. You might want to remove the redundancy.