### PR TITLE
chore: Fix Typos in Documentation Files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1456,7 +1456,7 @@ Removing the following field (deprecated on [2022-02-01](#2022-02-01)):
 
 ### Removed
 
-Some deprecated auction and offer fiels have been removed
+Some deprecated auction and offer fields have been removed
 
 `Offer`:
 

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ The token will expire after 30 days.
 
 Please refer to the `errors` field to understand why a `signIn` mutation failed.
 
-If `currentUser` is `null` and you don't have any `errors`, it's because the user has 2FA setup. Please follow the next section to handle 2FA signins.
+If `currentUser` is `null` and you don't have any `errors`, it's because the user has 2FA setup. Please follow the next section to handle 2FA signings.
 
 Please note also that if the token has been issued from a specific IP address and you try to generate it from another one, 2FA will automatically activate and you will need the code sent to your email to complete authentication.
 
@@ -194,7 +194,7 @@ $ curl 'https://api.sorare.com/graphql' \
 -H 'content-type: application/json' \
 -d '{
   "operationName": "SignInMutation",
-  "variables": { "input": { "otpSessionChallenge": "<YourOTPSessionChallenge>", "otpAttempt": "<YourOTPAttemp>" } },
+  "variables": { "input": { "otpSessionChallenge": "<YourOTPSessionChallenge>", "otpAttempt": "<YourOTPAttempt>" } },
   "query": "mutation SignInMutation($input: signInInput!) { signIn(input: $input) { currentUser { slug } jwtToken(aud: \"<YourAud>\") { token expiredAt } errors { message } } }"
 }'
 


### PR DESCRIPTION
This pull request fixes several typographical errors in the documentation files, including CHANGELOG.md and README.md.
- Corrected "fiels" to "fields" in CHANGELOG.md
- Corrected "signins" to "signings" in README.md
- Corrected "Attemp" to "Attempt" in README.md
Ensured consistency in variable naming and improved overall clarity.
These changes help improve the accuracy and professionalism of the project documentation.