### PR TITLE
Document self-serve OAuth app and API Key creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,11 +259,9 @@ Once terms are accepted, you will be able to sign in again.
 
 With our [OAuth](https://oauth.net/2/) API, users can sign-in to your service using their Sorare account, which allows you to request data on their behalf.
 
-In order to use our OAuth API, we need to issue you a Client ID and Secret for your application. You can request one through our [Help Center](https://help.sorare.com/hc/en-us/requests/new) with the following information:
+In order to use our OAuth API, we need to issue you a Client ID and Secret for your application.
 
-- A unique name for your application
-- One or more callback URLs (e.g., `http://localhost:3000/auth/sorare/callback` for development & `https://myapp.com/auth/sorare/callback` for production)
-- A logo for your application in PNG format
+You can create an OAuth application from [your developer settings](https://sorare.com/settings/developer).
 
 Sorare currently supports only the following OAuth 2.0 grant flows:
 
@@ -362,14 +360,16 @@ $ curl -X POST "https://api.sorare.com/oauth/revoke" \
 
 ## Rate limit
 
-The GraphQL API is rate limited. We can provide an extra API Key on demand that raises those limits.
+The GraphQL API is rate limited.
 
 Here are the configured limits:
 
 - Unauthenticated API calls: 20 calls per minute
 - Authenticated (JWT or OAuth) API calls: 60 calls per minute
-- API Key API calls: 600 calls per minute
+- API Key API calls: 200 calls per minute
 - 40 inflight queries. This only takes into account the backend/server processing part and excludes any network delays.
+
+You can create an API Key from [your developer settings](https://sorare.com/settings/developer).
 
 The API key should be passed in an http `APIKEY` header.
 
@@ -401,7 +401,7 @@ To stay within the limit, we recommend:
 
 ## GraphQL Complexity and Depth limits
 
-The GraphQL queries have complexity and depth limits. We can provide extra API keys (on demand) raising those limits.
+The GraphQL queries have complexity and depth limits. An API Key created from [your developer settings](https://sorare.com/settings/developer) raises those limits.
 
 - Depth reflects the longest nested fields chain.
 - Complexity reflects the potential total number of fields that would be returned. If the query asks for the first 50 cards, the complexity is computed on 50 cards, even if the result set is composed of 1 card.


### PR DESCRIPTION
## Why

OAuth app and API Key creation is now self-served from https://sorare.com/settings/developer. The README still pointed users to the Help Center and described a manual request flow with name/callback/logo, which no longer matches reality.

## Summary

- Replace Help Center request instructions with a link to developer settings for OAuth app creation.
- Add developer-settings link for API Key creation under Rate limit and Complexity/Depth limits sections.
- Update documented API Key rate limit to 200 calls/minute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)