### PR TITLE
Fix buildApprovals to accept privateKey parameter

### DIFF
--- a/examples/authorizations.js
+++ b/examples/authorizations.js
@@ -89,7 +89,7 @@ const buildApproval = (privateKey, fingerprint, authorizationRequest) => {
   throw new Error('Unknown authorization request type');
 };
 
-export const buildApprovals = authorizations => {
+export const buildApprovals = (privateKey, authorizations) => {
   return authorizations.map(authorization =>
     buildApproval(privateKey, authorization.fingerprint, authorization.request)
   );


### PR DESCRIPTION
## Summary

`buildApprovals` in `examples/authorizations.js` was defined with a single `authorizations` parameter, but every call site (`bidAuction.js`, `createSingleSaleOffer.js`, `acceptSingleSaleOffer.js`) and the README pass `buildApprovals(privateKey, authorizations)`.

The extra `privateKey` argument was silently dropped, and the `privateKey` referenced inside the function body was an undeclared free variable. Because these are ES modules (strict mode), running the example throws `ReferenceError: privateKey is not defined` before any authorization request is signed.

Fixing the example code
